### PR TITLE
Fixed bug where efficiency was always 0 in ExportSpotDataToCSV

### DIFF
--- a/SBFspot/CSVexport.cpp
+++ b/SBFspot/CSVexport.cpp
@@ -501,9 +501,6 @@ int ExportSpotDataToCSV(const Config *cfg, InverterData *inverters[])
 
 		for (int inv=0; inverters[inv]!=NULL && inv<MAX_INVERTERS; inv++)
 		{
-			//Calculated Inverter Efficiency
-			float calEfficiency = inverters[inv]->calPdcTot == 0 ? 0 : (float)inverters[inv]->calPacTot / (float)inverters[inv]->calPdcTot * 100;
-
 			if (cfg->SpotWebboxHeader == 0)
 			{
 				fputs(strftime_t(cfg->DateTimeFormat, spottime), csv);
@@ -529,7 +526,7 @@ int ExportSpotDataToCSV(const Config *cfg, InverterData *inverters[])
 			fprintf(csv, strout, cfg->delimiter, FormatFloat(FormattedFloat, (float)inverters[inv]->Uac3/100, 0, cfg->precision, cfg->decimalpoint));
 			fprintf(csv, strout, cfg->delimiter, FormatFloat(FormattedFloat, (float)inverters[inv]->calPdcTot, 0, cfg->precision, cfg->decimalpoint));
 			fprintf(csv, strout, cfg->delimiter, FormatFloat(FormattedFloat, (float)inverters[inv]->TotalPac, 0, cfg->precision, cfg->decimalpoint));
-			fprintf(csv, strout, cfg->delimiter, FormatFloat(FormattedFloat, calEfficiency, 0, cfg->precision, cfg->decimalpoint));
+			fprintf(csv, strout, cfg->delimiter, FormatFloat(FormattedFloat, inverters[inv]->calEfficiency, 0, cfg->precision, cfg->decimalpoint));
 			fprintf(csv, strout, cfg->delimiter, FormatDouble(FormattedFloat, (double)inverters[inv]->EToday/1000, 0, cfg->precision, cfg->decimalpoint));
 			fprintf(csv, strout, cfg->delimiter, FormatDouble(FormattedFloat, (double)inverters[inv]->ETotal/1000, 0, cfg->precision, cfg->decimalpoint));
 			fprintf(csv, strout, cfg->delimiter, FormatFloat(FormattedFloat, (float)inverters[inv]->GridFreq/100, 0, cfg->precision, cfg->decimalpoint));

--- a/SBFspot/SBFspot.cpp
+++ b/SBFspot/SBFspot.cpp
@@ -450,6 +450,7 @@ int main(int argc, char **argv)
             puts("DC Spot Data:");
             printf("\tString 1 Pdc: %7.3fkW - Udc: %6.2fV - Idc: %6.3fA\n", tokW(Inverters[inv]->Pdc1), toVolt(Inverters[inv]->Udc1), toAmp(Inverters[inv]->Idc1));
             printf("\tString 2 Pdc: %7.3fkW - Udc: %6.2fV - Idc: %6.3fA\n", tokW(Inverters[inv]->Pdc2), toVolt(Inverters[inv]->Udc2), toAmp(Inverters[inv]->Idc2));
+            printf("\tCalculated Total Pdc: %7.3fkW\n", tokW(Inverters[inv]->calPdcTot));
         }
     }
 
@@ -468,6 +469,9 @@ int main(int argc, char **argv)
 
     for (int inv=0; Inverters[inv]!=NULL && inv<MAX_INVERTERS; inv++)
     {
+        Inverters[inv]->calPacTot = Inverters[inv]->Pac1 + Inverters[inv]->Pac2 + Inverters[inv]->Pac3;
+        //Calculated Inverter Efficiency
+        Inverters[inv]->calEfficiency = Inverters[inv]->calPdcTot == 0 ? 0.0f : 100.0f * (float)Inverters[inv]->calPacTot / (float)Inverters[inv]->calPdcTot;
         if (VERBOSE_NORMAL)
         {
             printf("SUSyID: %d - SN: %lu\n", Inverters[inv]->SUSyID, Inverters[inv]->Serial);
@@ -475,7 +479,8 @@ int main(int argc, char **argv)
             printf("\tPhase 1 Pac : %7.3fkW - Uac: %6.2fV - Iac: %6.3fA\n", tokW(Inverters[inv]->Pac1), toVolt(Inverters[inv]->Uac1), toAmp(Inverters[inv]->Iac1));
             printf("\tPhase 2 Pac : %7.3fkW - Uac: %6.2fV - Iac: %6.3fA\n", tokW(Inverters[inv]->Pac2), toVolt(Inverters[inv]->Uac2), toAmp(Inverters[inv]->Iac2));
             printf("\tPhase 3 Pac : %7.3fkW - Uac: %6.2fV - Iac: %6.3fA\n", tokW(Inverters[inv]->Pac3), toVolt(Inverters[inv]->Uac3), toAmp(Inverters[inv]->Iac3));
-            printf("\tTotal Pac   : %7.3fkW\n", tokW(Inverters[inv]->TotalPac));
+            printf("\tTotal Pac   : %7.3fkW - Calculated Pac: %7.3fkW\n", tokW(Inverters[inv]->TotalPac), tokW(Inverters[inv]->calPacTot));
+            printf("\tEfficiency  : %7.2f%%\n", Inverters[inv]->calEfficiency);
         }
     }
 


### PR DESCRIPTION
Previously, the value 0 would always be written as efficiency in ExportSpotDataToCSV because calPacTot was always zero (it was never computed).

Furthermore, calEfficiency was written into a local variable instead of the dedicated field in the InverterData struct. This also means that ExportSpotDataToWSL, which uses the struct value, would have written 0 as efficiency.

The calculation of the calEfficiency and calPacTot is done as soon as SpotACPower,  SpotACVoltage and SpotACTotalPower have been read from the inverter(s).