### PR TITLE
add inverter power measurements from a connected energy meter

### DIFF
--- a/SBFspot/SBFspot.cfg
+++ b/SBFspot/SBFspot.cfg
@@ -219,7 +219,7 @@ MQTT_ItemDelimiter=comma
 MQTT_PublisherArgs=-h {host} -t {topic} -m "{{message}}"
 
 # Data to be published (comma delimited)
-MQTT_Data=Timestamp,SunRise,SunSet,InvSerial,InvName,InvTime,InvStatus,InvTemperature,InvGridRelay,EToday,ETotal,PACTot,UDC1,UDC2,IDC1,IDC2,PDC1,PDC2
+MQTT_Data=Timestamp,SunRise,SunSet,InvSerial,InvName,InvTime,InvStatus,InvTemperature,InvGridRelay,EToday,ETotal,PACTot,UDC1,UDC2,IDC1,IDC2,PDC1,PDC2,MeteringWTot
 
 # Possible keywords are (if supported by your inverter):
 # SBFspot Alias		Code				Description
@@ -258,4 +258,6 @@ MQTT_Data=Timestamp,SunRise,SunSet,InvSerial,InvName,InvTime,InvStatus,InvTemper
 # BatVol			BatVol				Battery voltage
 # BatAmp			BatAmp				Battery current
 # BatChaStt			BatChaStt			Current battery charge status
-
+# MeteringWOut                  MeteringGridMsTotWIn            current Power sent towards the Grid (W)
+# MeteringWIn                   MeteringGridMsTotWOut           current Power drawn from the Grid (W)
+# MeteringWTot                  MeteringGridMsTotW Out-In       current Power sent/drawn (negative when sending towards the net)

--- a/SBFspot/SBFspot.cpp
+++ b/SBFspot/SBFspot.cpp
@@ -556,6 +556,24 @@ int main(int argc, char **argv)
     }
 
     if (Inverters[0]->DevClass == SolarInverter)
+    {
+        if ((rc = getInverterData(Inverters, MeteringGridMsTotW)) != 0)
+            std::cerr << "getMeteringGridMsTotW returned an error: " << rc << std::endl;
+        else
+        {
+            for (int inv=0; Inverters[inv]!=NULL && inv<MAX_INVERTERS; inv++)
+            {
+                if (VERBOSE_NORMAL)
+                {
+                    printf("SUSyID: %d - SN: %lu\n", Inverters[inv]->SUSyID, Inverters[inv]->Serial);
+                    printf("Metering: GridMsTotWIn: %d\n", Inverters[inv]->MeteringGridMsTotWIn);
+                    printf("Metering: GridMsTotWOut: %d\n", Inverters[inv]->MeteringGridMsTotWOut);
+                }
+            }
+        }
+    }
+
+    if (Inverters[0]->DevClass == SolarInverter)
 	{
 		for (int inv=0; Inverters[inv]!=NULL && inv<MAX_INVERTERS; inv++)
 		{
@@ -3391,15 +3409,15 @@ int getInverterData(InverterData *devList[], enum getInverterDataType type)
 								devList[inv]->flags |= type;
 								break;
 
-							case MeteringGridMsTotWhOut:
+                           case MeteringGridMsTotWOut:
                                 if (recordsize == 0) recordsize = 28;
-								devList[inv]->MeteringGridMsTotWOut = value;
-								break;
+                                devList[inv]->MeteringGridMsTotWOut = value;
+                                break;
 
-							case MeteringGridMsTotWhIn:
+                           case MeteringGridMsTotWIn:
                                 if (recordsize == 0) recordsize = 28;
-								devList[inv]->MeteringGridMsTotWIn = value;
-								break;
+                                devList[inv]->MeteringGridMsTotWIn = value;
+                                break;
 
                             default:
                                 if (recordsize == 0) recordsize = 12;

--- a/SBFspot/mqtt.cpp
+++ b/SBFspot/mqtt.cpp
@@ -113,6 +113,12 @@ int mqtt_publish(const Config *cfg, InverterData *inverters[])
 			else if (key == "batvol")			FormatFloat(value, ((float)inverters[inv]->BatVol) / 100, 0, prec, dp);
 			else if (key == "batamp")			FormatFloat(value, ((float)inverters[inv]->BatAmp) / 1000, 0, prec, dp);
 			else if (key == "batchastt")		FormatFloat(value, ((float)inverters[inv]->BatChaStt), 0, prec, dp);
+			else if (key == "meteringwin")                  FormatFloat(value, (float)inverters[inv]->MeteringGridMsTotWIn, 0, prec, dp);
+                        else if (key == "meteringwout")                 FormatFloat(value, (float)inverters[inv]->MeteringGridMsTotWOut, 0, prec, dp);
+                        else if (key == "meteringwtot")                 FormatFloat(value, (float)inverters[inv]->MeteringGridMsTotWIn - (float)inverters[inv]->MeteringGridMsTotWOut, 0, prec, dp);
+
+
+
 
 			// None of the above, so it's an unhandled item or a typo...
 			else if (VERBOSE_NORMAL) std::cout << "MQTT: Don't know what to do with '" << *it << "'" << std::endl;


### PR DESCRIPTION
This PR adds support to retrieve the data from a connected SMA Energy Meter (see #419).
In order to work, the energymeter has to be configured as a datasource in the SMA inverter. This is usually the case if you use it for dynamic limiting your power insertion into the grid (70% regulation). 

If you add MeteringWTot to the mqtt output (see SBFspot.cfg) you will get the current power you draw from/deliver to the grid.