### PR TITLE
add inverter power measurements from a connected energy meter - master merged

### DIFF
--- a/SBFspot/Inverter.cpp
+++ b/SBFspot/Inverter.cpp
@@ -386,6 +386,24 @@ int Inverter::process()
 
     if (m_inverters[0]->DevClass == SolarInverter)
     {
+        if ((rc = getInverterData(m_inverters, MeteringGridMsTotW)) != 0)
+            std::cerr << "getMeteringGridMsTotW returned an error: " << rc << std::endl;
+        else
+        {
+            for (int inv=0; m_inverters[inv]!=NULL && inv<MAX_INVERTERS; inv++)
+            {
+                if (VERBOSE_NORMAL)
+                {
+                    printf("SUSyID: %d - SN: %lu\n", m_inverters[inv]->SUSyID, m_inverters[inv]->Serial);
+                    printf("Metering: GridMsTotWIn: %d\n", m_inverters[inv]->MeteringGridMsTotWIn);
+                    printf("Metering: GridMsTotWOut: %d\n", m_inverters[inv]->MeteringGridMsTotWOut);
+                }
+            }
+        }
+    }
+
+    if (m_inverters[0]->DevClass == SolarInverter)
+    {
         for (uint32_t inv=0; m_inverters[inv]!=NULL && inv<MAX_INVERTERS; inv++)
         {
             if (VERBOSE_NORMAL)

--- a/SBFspot/Inverter.cpp
+++ b/SBFspot/Inverter.cpp
@@ -390,7 +390,7 @@ int Inverter::process()
             std::cerr << "getMeteringGridMsTotW returned an error: " << rc << std::endl;
         else
         {
-            for (int inv=0; m_inverters[inv]!=NULL && inv<MAX_INVERTERS; inv++)
+            for (uint32_t inv=0; m_inverters[inv]!=NULL && inv<MAX_INVERTERS; inv++)
             {
                 if (VERBOSE_NORMAL)
                 {

--- a/SBFspot/SBFspot.cfg
+++ b/SBFspot/SBFspot.cfg
@@ -220,7 +220,7 @@ MQTT_ItemDelimiter=comma
 MQTT_PublisherArgs=-h {host} -t {topic} -m "{{message}}"
 
 # Data to be published (comma delimited)
-MQTT_Data=Timestamp,SunRise,SunSet,InvSerial,InvName,InvTime,InvStatus,InvTemperature,InvGridRelay,EToday,ETotal,PACTot,UDC1,UDC2,IDC1,IDC2,PDC1,PDC2
+MQTT_Data=Timestamp,SunRise,SunSet,InvSerial,InvName,InvTime,InvStatus,InvTemperature,InvGridRelay,EToday,ETotal,PACTot,UDC1,UDC2,IDC1,IDC2,PDC1,PDC2,MeteringWTot
 
 # Possible keywords are (if supported by your inverter):
 # SBFspot Alias		Code				Description
@@ -259,4 +259,6 @@ MQTT_Data=Timestamp,SunRise,SunSet,InvSerial,InvName,InvTime,InvStatus,InvTemper
 # BatVol			BatVol				Battery voltage
 # BatAmp			BatAmp				Battery current
 # BatChaStt			BatChaStt			Current battery charge status
-
+# MeteringWOut                  MeteringGridMsTotWIn            current Power sent towards the Grid (W)
+# MeteringWIn                   MeteringGridMsTotWOut           current Power drawn from the Grid (W)
+# MeteringWTot                  MeteringGridMsTotW Out-In       current Power sent/drawn (negative when sending towards the net)

--- a/SBFspot/SBFspot.cpp
+++ b/SBFspot/SBFspot.cpp
@@ -2712,15 +2712,15 @@ int getInverterData(InverterData *devList[], enum getInverterDataType type)
 								devList[inv]->flags |= type;
 								break;
 
-							case MeteringGridMsTotWhOut:
+                           case MeteringGridMsTotWOut:
                                 if (recordsize == 0) recordsize = 28;
-								devList[inv]->MeteringGridMsTotWOut = value;
-								break;
+                                devList[inv]->MeteringGridMsTotWOut = value;
+                                break;
 
-							case MeteringGridMsTotWhIn:
+                           case MeteringGridMsTotWIn:
                                 if (recordsize == 0) recordsize = 28;
-								devList[inv]->MeteringGridMsTotWIn = value;
-								break;
+                                devList[inv]->MeteringGridMsTotWIn = value;
+                                break;
 
                             default:
                                 if (recordsize == 0) recordsize = 12;

--- a/SBFspot/mqtt.cpp
+++ b/SBFspot/mqtt.cpp
@@ -113,6 +113,12 @@ int mqtt_publish(const Config *cfg, InverterData* const inverters[])
 			else if (key == "batvol")			FormatFloat(value, ((float)inverters[inv]->BatVol) / 100, 0, prec, dp);
 			else if (key == "batamp")			FormatFloat(value, ((float)inverters[inv]->BatAmp) / 1000, 0, prec, dp);
 			else if (key == "batchastt")		FormatFloat(value, ((float)inverters[inv]->BatChaStt), 0, prec, dp);
+			else if (key == "meteringwin")                  FormatFloat(value, (float)inverters[inv]->MeteringGridMsTotWIn, 0, prec, dp);
+                        else if (key == "meteringwout")                 FormatFloat(value, (float)inverters[inv]->MeteringGridMsTotWOut, 0, prec, dp);
+                        else if (key == "meteringwtot")                 FormatFloat(value, (float)inverters[inv]->MeteringGridMsTotWIn - (float)inverters[inv]->MeteringGridMsTotWOut, 0, prec, dp);
+
+
+
 
 			// None of the above, so it's an unhandled item or a typo...
 			else if (VERBOSE_NORMAL) std::cout << "MQTT: Don't know what to do with '" << *it << "'" << std::endl;


### PR DESCRIPTION
this is taking the pull request #420 from fishpepper and applying it on top of current version.

Limited Testing:
* Tested only with an inverter that does have an active connection to a Home Manager V2.
* Test only console output - MQTT not tested by me

Remaining issues:
* Error: sqlite3_exec() returned: 'UNIQUE constraint failed: SpotData.TimeStamp, SpotData.Serial' while executing
INSERT INTO SpotData VALUES( - But this issue is also present on my system on current master branch ==> not related to the proposed changes.
