### PR TITLE
Let executable return errors in Inverter::process()

### DIFF
--- a/SBFspot/main.cpp
+++ b/SBFspot/main.cpp
@@ -103,9 +103,9 @@ int main(int argc, char **argv)
     }
 
     Inverter inverter(cfg);
-    inverter.process();
+    rc = inverter.process();
 
     if (VERBOSE_NORMAL) print_error(stdout, PROC_INFO, "Done.\n");
 
-    return 0;
+    return rc;
 }


### PR DESCRIPTION
Right now errors in `Inverter::process()` aren't propagated to the caller.

Let's do that so that scripts can react to error conditions without parsing output.

Cheers