### PR TITLE
Convert quiet to bool in UploadDaemon too, to fix build after refactoring.

### DIFF
--- a/SBFspotUploadCommon/Configuration.h
+++ b/SBFspotUploadCommon/Configuration.h
@@ -45,7 +45,7 @@ DISCLAIMER:
 #include <sstream>
 #include <fstream>
 
-extern int quiet;
+extern bool quiet;
 extern int verbose;
 
 typedef unsigned int SMASerial;

--- a/SBFspotUploadCommon/PVOutput.h
+++ b/SBFspotUploadCommon/PVOutput.h
@@ -43,7 +43,7 @@ DISCLAIMER:
 #include <vector>
 #include <map>
 
-extern int quiet;
+extern bool quiet;
 extern int verbose;
 
 class PVOutput

--- a/SBFspotUploadDaemon/main.cpp
+++ b/SBFspotUploadDaemon/main.cpp
@@ -46,7 +46,7 @@ DISCLAIMER:
 #include <vector>
 #include <string.h>
 
-int quiet;
+bool quiet;
 int verbose;
 
 bool bStopping = false;


### PR DESCRIPTION
UploadDaemon build was broken by https://github.com/SBFspot/SBFspot/commit/e6e975fbc2d24bb77ceb07fe8371cbc08246f97b;

```
../SBFspotUploadCommon/PVOutput.h:46:12: error: conflicting declaration 'int quiet'
../SBFspotUploadCommon/Configuration.h:48:12: error: conflicting declaration 'int quiet'
main.cpp:49:5: error: conflicting declaration 'int quiet'
```