### PR TITLE
Fixed misleading unit in EToday and ETotal

### DIFF
--- a/SBFspot/SBFspot.cfg
+++ b/SBFspot/SBFspot.cfg
@@ -243,8 +243,8 @@ MQTT_Data=Timestamp,SunRise,SunSet,InvSerial,InvName,InvTime,InvStatus,InvTemper
 # InvStatus         OperationHealth         Condition
 # InvTemperature    CoolsysTmpNom           Operating condition temperatures
 # InvGridRelay      OperationGriSwStt       Grid relay/contactor
-# ETotal            MeteringTotWhOut        Total yield
-# EToday            MeteringDyWhOut         Day yield
+# ETotal            MeteringTotkWhOut        Total yield
+# EToday            MeteringDykWhOut         Day yield
 # PACTot            GridMsTotW              Power
 # PDC1/PDC2/PDC     DcMsWatt                DC power input string 1/2/All
 # UDC1/UDC2/UDC     DcMsVol                 DC voltage input string 1/2/All

--- a/SBFspot/SBFspot.cfg
+++ b/SBFspot/SBFspot.cfg
@@ -243,8 +243,8 @@ MQTT_Data=Timestamp,SunRise,SunSet,InvSerial,InvName,InvTime,InvStatus,InvTemper
 # InvStatus         OperationHealth         Condition
 # InvTemperature    CoolsysTmpNom           Operating condition temperatures
 # InvGridRelay      OperationGriSwStt       Grid relay/contactor
-# ETotal            MeteringTotkWhOut        Total yield
-# EToday            MeteringDykWhOut         Day yield
+# ETotal            MeteringTotWhOut        Total yield (kWh)
+# EToday            MeteringDyWhOut         Day yield (kWh)
 # PACTot            GridMsTotW              Power
 # PDC1/PDC2/PDC     DcMsWatt                DC power input string 1/2/All
 # UDC1/UDC2/UDC     DcMsVol                 DC voltage input string 1/2/All


### PR DESCRIPTION
EToday and ETotal is in kWh and not Wh which is slightly misleading 